### PR TITLE
fix: running project locally

### DIFF
--- a/password_manager/settings.py
+++ b/password_manager/settings.py
@@ -28,7 +28,11 @@ SECRET_KEY = (
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["secure-password-manager-475618.uc.r.appspot.com"]
+ALLOWED_HOSTS = [
+    "secure-password-manager-475618.uc.r.appspot.com",
+    "localhost",
+    "127.0.0.1",
+]
 
 
 # Application definition


### PR DESCRIPTION
Fixes bug introduced with feat/googlecloud.
Allows development server to run locally with `python manage.py runserver`