### PR TITLE
fix: error messages on RecordForm

### DIFF
--- a/GenAI_transcripts/2025_11_24_Cursor_Error_Message_Display.md
+++ b/GenAI_transcripts/2025_11_24_Cursor_Error_Message_Display.md
@@ -1,0 +1,2110 @@
+# Why is the email error not displayed?
+_Exported on 11/24/2025 at 18:14:00 EST from Cursor (2.0.77)_
+
+---
+
+**User**
+
+I just tried to create a new vault record on the web application and got these errors in console:
+
+Why did the "enter a valid email address" error not display on screen?
+
+---
+
+**Cursor**
+
+I'll investigate why the email validation error from the API isn't displaying in the UI.
+
+Now let me check where this form is used and how errors are handled:
+
+Now let me check the Input component to see if it already supports error display:
+
+Let me check how API errors are structured:
+
+```plaintext
+{
+  status: number,
+  message: string,
+  data: unknown  // This is the parsed JSON response body
+}
+```
+
+```plaintext
+{
+  email: ["Enter a valid email address."]
+}
+```
+
+Now I can see the issue. The email validation error from the API is not being displayed because:
+
+1. **API error structure**: The API returns validation errors in the response body as `{email: ["Enter a valid email address."]}`
+2. **Error handling in Vault.tsx**: The `performMutation` function catches errors but only extracts a generic message, not field-specific validation errors
+3. **RecordForm component**: Doesn't accept or display field-specific errors, even though the `Input` component already supports an `error` prop
+
+Let me fix this by:
+1. Updating `RecordForm` to accept and display field-specific errors
+2. Updating error handling in `Vault.tsx` to extract validation errors from the API response
+
+```typescriptreact
+// GenAI Citation for April:
+// Portions of this code was generated/refactored with the help of Cursor with the Claude-4.5-sonnet model
+// The conversation in the file below documents the GenAI Interaction that led to my code.
+// ../GenAI_transcripts/2025_11_15_Cursor_refactor_UI.md
+// ../GenAI_transcripts/2025_11_14_Cursor_style_Vault_components.md
+// ../GenAI_transcripts/2025_11_18_Cursor_RecordForm_UI_refactor.md
+
+import { useState, type FC, type FormEvent } from "react";
+import type { VaultRecord } from "../types/VaultRecord";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import {Button} from "./Button";
+import {Input, Textarea} from "./Input";
+import styles from "./RecordForm.module.css";
+
+interface RecordFormProps {
+    record: VaultRecord | null;
+    onSubmit: (record: VaultRecord) => Promise<void>;
+    onCancel: () => void;
+    fieldErrors?: Record<string, string[]>;
+}
+
+export const RecordForm:FC<RecordFormProps> = ({record, onSubmit, onCancel, fieldErrors = {}}) => {
+
+    const [formState, setFormState] = useState<Pick<VaultRecord, 'title' | 'username' | 'password' | 'email' | 'url' | 'notes'>>({
+        title: record?.title ?? '',
+        username: record?.username ?? '',
+        password: record?.password ?? '',
+        email: record?.email ?? '',
+        url: record?.url ?? '',
+        notes: record?.notes ?? '',
+    });
+
+    const [showPassword, setShowPassword] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const PasswordToggleButton = () => (
+        <button
+            type="button"
+            className={styles.toggleButton}
+            onClick={() => setShowPassword(!showPassword)}
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+        >
+            <FontAwesomeIcon icon={showPassword ? faEyeSlash : faEye} />
+        </button>
+    );
+
+    const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        setIsSubmitting(true);
+        try {
+            await onSubmit({
+                ...formState,
+                id: record?.id ?? 0,
+                created_at: record?.created_at ?? new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            });
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    const isNewRecord = record === null;
+
+    const formContent = (
+        <form className={styles.recordForm} onSubmit={handleSubmit}>
+            <h3>{isNewRecord ? 'Add New Record' : 'Edit Record'}</h3>
+            <Input
+                label="Title:"
+                type="text"
+                value={formState.title}
+                required
+                onChange={(e) => setFormState({...formState, title: e.target.value})}
+            />
+            <Input
+                label="Username:"
+                type="text"
+                value={formState.username}
+                required
+                onChange={(e) => setFormState({...formState, username: e.target.value})}
+            />
+            <Input
+                label="Password:"
+                type={showPassword ? "text" : "password"}
+                value={formState.password}
+                required
+                onChange={(e) => setFormState({...formState, password: e.target.value})}
+                secondaryRightAdornment={<PasswordToggleButton />}
+            />
+            <Input
+                label="Email:"
+                type="email"
+                value={formState.email}
+                onChange={(e) => setFormState({...formState, email: e.target.value})}
+                helperText="Optional - Associated email address"
+            />
+            <Input
+                label="URL:"
+                type="url"
+                value={formState.url}
+                onChange={(e) => setFormState({...formState, url: e.target.value})}
+                helperText="Optional - Website URL"
+            />
+            <Textarea
+                label="Notes:"
+                value={formState.notes}
+                onChange={(e) => setFormState({...formState, notes: e.target.value})}
+                helperText="Optional - Additional information"
+            />
+            <div className={styles.buttonGroup}>
+                <Button type="submit" variant="primary" isLoading={isSubmitting}>
+                    {isNewRecord ? 'Add' : 'Save'}
+                </Button>
+                <Button type="button" variant="secondary" onClick={onCancel} disabled={isSubmitting}>
+                    Cancel
+                </Button>
+            </div>
+        </form>
+    );
+
+    if (isNewRecord) {
+        return (
+            <div className={styles.dialogOverlay} onClick={onCancel}>
+                <div className={styles.dialogContent} onClick={(e) => e.stopPropagation()}>
+                    {formContent}
+                </div>
+            </div>
+        );
+    }
+
+    return formContent;
+}
+```
+
+```typescriptreact
+// GenAI Citation for April:
+// Portions of this code was generated/refactored with the help of Cursor with the Claude-4.5-sonnet model
+// The conversation in the file below documents the GenAI Interaction that led to my code.
+// ../GenAI_transcripts/2025_11_15_Cursor_refactor_UI.md
+// ../GenAI_transcripts/2025_11_14_Cursor_style_Vault_components.md
+// ../GenAI_transcripts/2025_11_18_Cursor_RecordForm_UI_refactor.md
+
+import { useState, type FC, type FormEvent } from "react";
+import type { VaultRecord } from "../types/VaultRecord";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import {Button} from "./Button";
+import {Input, Textarea} from "./Input";
+import styles from "./RecordForm.module.css";
+
+interface RecordFormProps {
+    record: VaultRecord | null;
+    onSubmit: (record: VaultRecord) => Promise<void>;
+    onCancel: () => void;
+    fieldErrors?: Record<string, string[]>;
+}
+
+export const RecordForm:FC<RecordFormProps> = ({record, onSubmit, onCancel, fieldErrors = {}}) => {
+
+    const [formState, setFormState] = useState<Pick<VaultRecord, 'title' | 'username' | 'password' | 'email' | 'url' | 'notes'>>({
+        title: record?.title ?? '',
+        username: record?.username ?? '',
+        password: record?.password ?? '',
+        email: record?.email ?? '',
+        url: record?.url ?? '',
+        notes: record?.notes ?? '',
+    });
+
+    const [showPassword, setShowPassword] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const PasswordToggleButton = () => (
+        <button
+            type="button"
+            className={styles.toggleButton}
+            onClick={() => setShowPassword(!showPassword)}
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+        >
+            <FontAwesomeIcon icon={showPassword ? faEyeSlash : faEye} />
+        </button>
+    );
+
+    const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        setIsSubmitting(true);
+        try {
+            await onSubmit({
+                ...formState,
+                id: record?.id ?? 0,
+                created_at: record?.created_at ?? new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            });
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    const isNewRecord = record === null;
+
+    const formContent = (
+        <form className={styles.recordForm} onSubmit={handleSubmit}>
+            <h3>{isNewRecord ? 'Add New Record' : 'Edit Record'}</h3>
+            <Input
+                label="Title:"
+                type="text"
+                value={formState.title}
+                required
+                onChange={(e) => setFormState({...formState, title: e.target.value})}
+            />
+            <Input
+                label="Username:"
+                type="text"
+                value={formState.username}
+                required
+                onChange={(e) => setFormState({...formState, username: e.target.value})}
+            />
+            <Input
+                label="Password:"
+                type={showPassword ? "text" : "password"}
+                value={formState.password}
+                required
+                onChange={(e) => setFormState({...formState, password: e.target.value})}
+                secondaryRightAdornment={<PasswordToggleButton />}
+            />
+            <Input
+                label="Email:"
+                type="email"
+                value={formState.email}
+                onChange={(e) => setFormState({...formState, email: e.target.value})}
+                error={fieldErrors.email?.[0]}
+                helperText={!fieldErrors.email ? "Optional - Associated email address" : undefined}
+            />
+            <Input
+                label="URL:"
+                type="url"
+                value={formState.url}
+                onChange={(e) => setFormState({...formState, url: e.target.value})}
+                error={fieldErrors.url?.[0]}
+                helperText={!fieldErrors.url ? "Optional - Website URL" : undefined}
+            />
+            <Textarea
+                label="Notes:"
+                value={formState.notes}
+                onChange={(e) => setFormState({...formState, notes: e.target.value})}
+                error={fieldErrors.notes?.[0]}
+                helperText={!fieldErrors.notes ? "Optional - Additional information" : undefined}
+            />
+            <div className={styles.buttonGroup}>
+                <Button type="submit" variant="primary" isLoading={isSubmitting}>
+                    {isNewRecord ? 'Add' : 'Save'}
+                </Button>
+                <Button type="button" variant="secondary" onClick={onCancel} disabled={isSubmitting}>
+                    Cancel
+                </Button>
+            </div>
+        </form>
+    );
+
+    if (isNewRecord) {
+        return (
+            <div className={styles.dialogOverlay} onClick={onCancel}>
+                <div className={styles.dialogContent} onClick={(e) => e.stopPropagation()}>
+                    {formContent}
+                </div>
+            </div>
+        );
+    }
+
+    return formContent;
+}
+```
+
+```typescriptreact
+// GenAI Citation for April:
+// Portions of this code was generated/refactored with the help of Cursor with the Claude-4.5-sonnet model
+// The conversation in the file below documents the GenAI Interaction that led to my code.
+// ../GenAI_transcripts/2025_11_15_Cursor_refactor_UI.md
+// ../GenAI_transcripts/2025_11_14_Cursor_style_Vault_components.md
+// ../GenAI_transcripts/2025_11_18_Cursor_RecordForm_UI_refactor.md
+
+import { useState, type FC, type FormEvent } from "react";
+import type { VaultRecord } from "../types/VaultRecord";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import {Button} from "./Button";
+import {Input, Textarea} from "./Input";
+import styles from "./RecordForm.module.css";
+
+interface RecordFormProps {
+    record: VaultRecord | null;
+    onSubmit: (record: VaultRecord) => Promise<void>;
+    onCancel: () => void;
+    fieldErrors?: Record<string, string[]>;
+}
+
+export const RecordForm:FC<RecordFormProps> = ({record, onSubmit, onCancel, fieldErrors = {}}) => {
+
+    const [formState, setFormState] = useState<Pick<VaultRecord, 'title' | 'username' | 'password' | 'email' | 'url' | 'notes'>>({
+        title: record?.title ?? '',
+        username: record?.username ?? '',
+        password: record?.password ?? '',
+        email: record?.email ?? '',
+        url: record?.url ?? '',
+        notes: record?.notes ?? '',
+    });
+
+    const [showPassword, setShowPassword] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const PasswordToggleButton = () => (
+        <button
+            type="button"
+            className={styles.toggleButton}
+            onClick={() => setShowPassword(!showPassword)}
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+        >
+            <FontAwesomeIcon icon={showPassword ? faEyeSlash : faEye} />
+        </button>
+    );
+
+    const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        setIsSubmitting(true);
+        try {
+            await onSubmit({
+                ...formState,
+                id: record?.id ?? 0,
+                created_at: record?.created_at ?? new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            });
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    const isNewRecord = record === null;
+
+    const formContent = (
+        <form className={styles.recordForm} onSubmit={handleSubmit}>
+            <h3>{isNewRecord ? 'Add New Record' : 'Edit Record'}</h3>
+            <Input
+                label="Title:"
+                type="text"
+                value={formState.title}
+                required
+                onChange={(e) => setFormState({...formState, title: e.target.value})}
+                error={fieldErrors.title?.[0]}
+            />
+            <Input
+                label="Username:"
+                type="text"
+                value={formState.username}
+                required
+                onChange={(e) => setFormState({...formState, username: e.target.value})}
+                error={fieldErrors.username?.[0]}
+            />
+            <Input
+                label="Password:"
+                type={showPassword ? "text" : "password"}
+                value={formState.password}
+                required
+                onChange={(e) => setFormState({...formState, password: e.target.value})}
+                secondaryRightAdornment={<PasswordToggleButton />}
+                error={fieldErrors.password?.[0]}
+            />
+            <Input
+                label="Email:"
+                type="email"
+                value={formState.email}
+                onChange={(e) => setFormState({...formState, email: e.target.value})}
+                error={fieldErrors.email?.[0]}
+                helperText={!fieldErrors.email ? "Optional - Associated email address" : undefined}
+            />
+            <Input
+                label="URL:"
+                type="url"
+                value={formState.url}
+                onChange={(e) => setFormState({...formState, url: e.target.value})}
+                error={fieldErrors.url?.[0]}
+                helperText={!fieldErrors.url ? "Optional - Website URL" : undefined}
+            />
+            <Textarea
+                label="Notes:"
+                value={formState.notes}
+                onChange={(e) => setFormState({...formState, notes: e.target.value})}
+                error={fieldErrors.notes?.[0]}
+                helperText={!fieldErrors.notes ? "Optional - Additional information" : undefined}
+            />
+            <div className={styles.buttonGroup}>
+                <Button type="submit" variant="primary" isLoading={isSubmitting}>
+                    {isNewRecord ? 'Add' : 'Save'}
+                </Button>
+                <Button type="button" variant="secondary" onClick={onCancel} disabled={isSubmitting}>
+                    Cancel
+                </Button>
+            </div>
+        </form>
+    );
+
+    if (isNewRecord) {
+        return (
+            <div className={styles.dialogOverlay} onClick={onCancel}>
+                <div className={styles.dialogContent} onClick={(e) => e.stopPropagation()}>
+                    {formContent}
+                </div>
+            </div>
+        );
+    }
+
+    return formContent;
+}
+```
+
+Now let me update `Vault.tsx` to extract and pass field-specific validation errors:
+
+```typescriptreact
+/*
+This creates the Vault page using React.
+
+Note:
+To start the Vite dev server, run: 'npm run dev' in the frontend/web directory.
+
+GenAI Citation for April:
+Portions of this code was generated/refactored with the help of Cursor with the Claude-4.5-sonnet model
+The conversation in the file below documents the GenAI Interaction that led to my code.
+../GenAI_transcripts/2025_11_14_Cursor_generate_dummy_data_for_Vault.md
+../GenAI_transcripts/2025_11_14_Cursor_style_Vault_components.md
+*/
+
+import { useState, useEffect, useCallback } from 'react';
+import type { VaultRecord as VaultRecord } from '../types/VaultRecord';
+import styles from './Vault.module.css';
+import { VaultList } from '../components/VaultList';
+import { RecordForm } from '../components/RecordForm';
+import { RecordDetails } from '../components/RecordDetails';
+import { LoadingSpinner } from '../components/LoadingSpinner';
+import { Spacer } from '../components/Spacer';
+import { apiRequest } from '../utils/http/apiRequest';
+import { useVaultKey } from '../contexts/useVaultKey';
+import { encryptVaultEntry } from '../utils/crypto/encryptVaultEntry';
+import { decryptVaultEntry } from '../utils/crypto/decryptVaultEntry';
+
+
+export const VaultPage = () => {
+    const [records, setRecords] = useState<VaultRecord[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+
+    const [editingRecord, setEditingRecord] = useState<VaultRecord | null | undefined>(undefined);
+    const [selectedRecord, setSelectedRecord] = useState<VaultRecord | null >(null);
+    
+    const { vaultKey } = useVaultKey();
+
+    const getErrorMessage = (err: unknown): string => {
+        if (err instanceof Error) return err.message;
+        if (typeof err === 'object' && err !== null && 'message' in err) {
+          return String(err.message);
+        }
+        return 'An error occurred';
+      };
+
+    const fetchRecords = useCallback(async () => {
+        if (!vaultKey) {
+            setError('Vault key not available. Please log in again.');
+            setLoading(false);
+            return;
+        }
+
+        try {
+            setLoading(true);
+            const {data} = await apiRequest<VaultRecord[]>('/api/vault/records/', {
+              method: 'GET',
+              requiresAuth: true
+            });
+            
+            // Decrypt sensitive fields
+            const decryptedRecords = await Promise.all(
+                data.map(async (record) => ({
+                    ...record,
+                    password: await decryptVaultEntry(vaultKey, record.password),
+                    notes: record.notes ? await decryptVaultEntry(vaultKey, record.notes) : '',
+                }))
+            );
+            
+            setRecords(decryptedRecords);
+          } catch (err) {
+            setError(getErrorMessage(err));
+            console.error('Error fetching records:', err);
+          } finally {
+            setLoading(false);
+          }
+    }, [vaultKey]);
+
+    // Mutations without loading spinner
+    const performMutation = async function<T>(
+        apiCall: Promise<T>
+    ): Promise<boolean> {
+        try {
+            setError(null);
+            await apiCall;
+            await fetchRecords(); // Re-fetch after any mutation
+            return true;
+        } catch (err) {
+            setError(getErrorMessage(err));
+            console.error('Error:', err);
+            return false;
+        }
+    };
+
+    useEffect(() => {
+        fetchRecords();
+      }, [fetchRecords]);
+
+    const onAddRecord = () => {
+        setEditingRecord(null);
+        }
+    
+    const onEditRecord = (record: VaultRecord) => {
+        setEditingRecord(record);
+    }
+
+    const onSelectRecord = (record: VaultRecord) => {
+        setSelectedRecord(record);
+    }
+
+    const onCancel = () => {
+        setEditingRecord(undefined);
+    }
+
+    const onCloseDetails = () => {
+        setSelectedRecord(null);
+    }
+
+    const onDeleteRecord = async (record: VaultRecord) => {
+        const success = await performMutation(
+        apiRequest(`/api/vault/records/${record.id}/`, {
+            method: 'DELETE',
+            requiresAuth: true
+        }));
+        if (success) {
+            setSelectedRecord(null);
+        }
+    }
+
+    const handleRecordSubmit = async (record: VaultRecord) => {
+        if (!vaultKey) {
+            setError('Vault key not available. Cannot save record.');
+            return;
+        }
+
+        // Encrypt sensitive fields before sending
+        const encryptedRecord = {
+            ...record,
+            password: await encryptVaultEntry(vaultKey, record.password),
+            notes: record.notes ? await encryptVaultEntry(vaultKey, record.notes) : '',
+        };
+
+        const success = await performMutation(
+            apiRequest(
+                editingRecord ? `/api/vault/records/${editingRecord.id}/` : '/api/vault/records/',
+                {
+                    method: editingRecord ? 'PUT' : 'POST',
+                    body: encryptedRecord,
+                    requiresAuth: true
+                }
+            ));
+        if (success) {
+            setEditingRecord(undefined);
+        }
+    }
+    
+    
+    return (
+        <div className={styles.vaultContainer}>
+            <div className={styles.vaultContent}>
+                <h1>Vault</h1>
+
+                {loading && (
+                    <Spacer paddingY="xl">
+                        <LoadingSpinner size="large" text="Loading your vault..." />
+                    </Spacer>
+                )}
+
+                {error && <p style={{ color: 'var(--color-error)' }}>Error: {error}</p>}
+
+                {!loading && !error && (
+                <div className={styles.vaultLayout}>
+                    <div className={styles.leftColumn}>
+                        <VaultList 
+                            records={records} 
+                            onAddRecord={onAddRecord} 
+                            onEditRecord={onEditRecord} 
+                            onSelectRecord={onSelectRecord}
+                        />
+                    </div>
+                    <div className={styles.rightColumn}>
+
+                        {editingRecord !== undefined && (
+                            <RecordForm 
+                                record={editingRecord} 
+                                onSubmit={handleRecordSubmit} 
+                                onCancel={onCancel} 
+                            />
+                        )}
+                        
+                        {selectedRecord && editingRecord === undefined && (
+                            <RecordDetails 
+                                record={selectedRecord} 
+                                onClose={onCloseDetails}
+                                onDelete={onDeleteRecord}
+                            />
+                        )}
+                    </div>
+                </div>
+            )}
+            </div>
+        </div>
+    )
+}
+```
+
+```typescriptreact
+/*
+This creates the Vault page using React.
+
+Note:
+To start the Vite dev server, run: 'npm run dev' in the frontend/web directory.
+
+GenAI Citation for April:
+Portions of this code was generated/refactored with the help of Cursor with the Claude-4.5-sonnet model
+The conversation in the file below documents the GenAI Interaction that led to my code.
+../GenAI_transcripts/2025_11_14_Cursor_generate_dummy_data_for_Vault.md
+../GenAI_transcripts/2025_11_14_Cursor_style_Vault_components.md
+*/
+
+import { useState, useEffect, useCallback } from 'react';
+import type { VaultRecord as VaultRecord } from '../types/VaultRecord';
+import styles from './Vault.module.css';
+import { VaultList } from '../components/VaultList';
+import { RecordForm } from '../components/RecordForm';
+import { RecordDetails } from '../components/RecordDetails';
+import { LoadingSpinner } from '../components/LoadingSpinner';
+import { Spacer } from '../components/Spacer';
+import { apiRequest } from '../utils/http/apiRequest';
+import { useVaultKey } from '../contexts/useVaultKey';
+import { encryptVaultEntry } from '../utils/crypto/encryptVaultEntry';
+import { decryptVaultEntry } from '../utils/crypto/decryptVaultEntry';
+
+
+export const VaultPage = () => {
+    const [records, setRecords] = useState<VaultRecord[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+
+    const [editingRecord, setEditingRecord] = useState<VaultRecord | null | undefined>(undefined);
+    const [selectedRecord, setSelectedRecord] = useState<VaultRecord | null >(null);
+    
+    const { vaultKey } = useVaultKey();
+
+    const getErrorMessage = (err: unknown): string => {
+        if (err instanceof Error) return err.message;
+        if (typeof err === 'object' && err !== null && 'message' in err) {
+          return String(err.message);
+        }
+        return 'An error occurred';
+      };
+
+    const extractFieldErrors = (err: unknown): Record<string, string[]> => {
+        if (typeof err === 'object' && err !== null && 'data' in err) {
+            const data = (err as { data: unknown }).data;
+            if (typeof data === 'object' && data !== null) {
+                // Filter out non-field error properties
+                const fieldErrors: Record<string, string[]> = {};
+                for (const [key, value] of Object.entries(data)) {
+                    if (Array.isArray(value)) {
+                        fieldErrors[key] = value;
+                    }
+                }
+                return fieldErrors;
+            }
+        }
+        return {};
+    };
+
+    const fetchRecords = useCallback(async () => {
+        if (!vaultKey) {
+            setError('Vault key not available. Please log in again.');
+            setLoading(false);
+            return;
+        }
+
+        try {
+            setLoading(true);
+            const {data} = await apiRequest<VaultRecord[]>('/api/vault/records/', {
+              method: 'GET',
+              requiresAuth: true
+            });
+            
+            // Decrypt sensitive fields
+            const decryptedRecords = await Promise.all(
+                data.map(async (record) => ({
+                    ...record,
+                    password: await decryptVaultEntry(vaultKey, record.password),
+                    notes: record.notes ? await decryptVaultEntry(vaultKey, record.notes) : '',
+                }))
+            );
+            
+            setRecords(decryptedRecords);
+          } catch (err) {
+            setError(getErrorMessage(err));
+            console.error('Error fetching records:', err);
+          } finally {
+            setLoading(false);
+          }
+    }, [vaultKey]);
+
+    // Mutations without loading spinner
+    const performMutation = async function<T>(
+        apiCall: Promise<T>
+    ): Promise<boolean> {
+        try {
+            setError(null);
+            await apiCall;
+            await fetchRecords(); // Re-fetch after any mutation
+            return true;
+        } catch (err) {
+            setError(getErrorMessage(err));
+            console.error('Error:', err);
+            return false;
+        }
+    };
+
+    useEffect(() => {
+        fetchRecords();
+      }, [fetchRecords]);
+
+    const onAddRecord = () => {
+        setEditingRecord(null);
+        }
+    
+    const onEditRecord = (record: VaultRecord) => {
+        setEditingRecord(record);
+    }
+
+    const onSelectRecord = (record: VaultRecord) => {
+        setSelectedRecord(record);
+    }
+
+    const onCancel = () => {
+        setEditingRecord(undefined);
+    }
+
+    const onCloseDetails = () => {
+        setSelectedRecord(null);
+    }
+
+    const onDeleteRecord = async (record: VaultRecord) => {
+        const success = await performMutation(
+        apiRequest(`/api/vault/records/${record.id}/`, {
+            method: 'DELETE',
+            requiresAuth: true
+        }));
+        if (success) {
+            setSelectedRecord(null);
+        }
+    }
+
+    const handleRecordSubmit = async (record: VaultRecord) => {
+        if (!vaultKey) {
+            setError('Vault key not available. Cannot save record.');
+            return;
+        }
+
+        // Encrypt sensitive fields before sending
+        const encryptedRecord = {
+            ...record,
+            password: await encryptVaultEntry(vaultKey, record.password),
+            notes: record.notes ? await encryptVaultEntry(vaultKey, record.notes) : '',
+        };
+
+        const success = await performMutation(
+            apiRequest(
+                editingRecord ? `/api/vault/records/${editingRecord.id}/` : '/api/vault/records/',
+                {
+                    method: editingRecord ? 'PUT' : 'POST',
+                    body: encryptedRecord,
+                    requiresAuth: true
+                }
+            ));
+        if (success) {
+            setEditingRecord(undefined);
+        }
+    }
+    
+    
+    return (
+        <div className={styles.vaultContainer}>
+            <div className={styles.vaultContent}>
+                <h1>Vault</h1>
+
+                {loading && (
+                    <Spacer paddingY="xl">
+                        <LoadingSpinner size="large" text="Loading your vault..." />
+                    </Spacer>
+                )}
+
+                {error && <p style={{ color: 'var(--color-error)' }}>Error: {error}</p>}
+
+                {!loading && !error && (
+                <div className={styles.vaultLayout}>
+                    <div className={styles.leftColumn}>
+                        <VaultList 
+                            records={records} 
+                            onAddRecord={onAddRecord} 
+                            onEditRecord={onEditRecord} 
+                            onSelectRecord={onSelectRecord}
+                        />
+                    </div>
+                    <div className={styles.rightColumn}>
+
+                        {editingRecord !== undefined && (
+                            <RecordForm 
+                                record={editingRecord} 
+                                onSubmit={handleRecordSubmit} 
+                                onCancel={onCancel} 
+                            />
+                        )}
+                        
+                        {selectedRecord && editingRecord === undefined && (
+                            <RecordDetails 
+                                record={selectedRecord} 
+                                onClose={onCloseDetails}
+                                onDelete={onDeleteRecord}
+                            />
+                        )}
+                    </div>
+                </div>
+            )}
+            </div>
+        </div>
+    )
+}
+```
+
+```typescriptreact
+/*
+This creates the Vault page using React.
+
+Note:
+To start the Vite dev server, run: 'npm run dev' in the frontend/web directory.
+
+GenAI Citation for April:
+Portions of this code was generated/refactored with the help of Cursor with the Claude-4.5-sonnet model
+The conversation in the file below documents the GenAI Interaction that led to my code.
+../GenAI_transcripts/2025_11_14_Cursor_generate_dummy_data_for_Vault.md
+../GenAI_transcripts/2025_11_14_Cursor_style_Vault_components.md
+*/
+
+import { useState, useEffect, useCallback } from 'react';
+import type { VaultRecord as VaultRecord } from '../types/VaultRecord';
+import styles from './Vault.module.css';
+import { VaultList } from '../components/VaultList';
+import { RecordForm } from '../components/RecordForm';
+import { RecordDetails } from '../components/RecordDetails';
+import { LoadingSpinner } from '../components/LoadingSpinner';
+import { Spacer } from '../components/Spacer';
+import { apiRequest } from '../utils/http/apiRequest';
+import { useVaultKey } from '../contexts/useVaultKey';
+import { encryptVaultEntry } from '../utils/crypto/encryptVaultEntry';
+import { decryptVaultEntry } from '../utils/crypto/decryptVaultEntry';
+
+
+export const VaultPage = () => {
+    const [records, setRecords] = useState<VaultRecord[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+
+    const [editingRecord, setEditingRecord] = useState<VaultRecord | null | undefined>(undefined);
+    const [selectedRecord, setSelectedRecord] = useState<VaultRecord | null >(null);
+    
+    const { vaultKey } = useVaultKey();
+
+    const getErrorMessage = (err: unknown): string => {
+        if (err instanceof Error) return err.message;
+        if (typeof err === 'object' && err !== null && 'message' in err) {
+          return String(err.message);
+        }
+        return 'An error occurred';
+      };
+
+    const extractFieldErrors = (err: unknown): Record<string, string[]> => {
+        if (typeof err === 'object' && err !== null && 'data' in err) {
+            const data = (err as { data: unknown }).data;
+            if (typeof data === 'object' && data !== null) {
+                // Filter out non-field error properties
+                const fieldErrors: Record<string, string[]> = {};
+                for (const [key, value] of Object.entries(data)) {
+                    if (Array.isArray(value)) {
+                        fieldErrors[key] = value;
+                    }
+                }
+                return fieldErrors;
+            }
+        }
+        return {};
+    };
+
+    const fetchRecords = useCallback(async () => {
+        if (!vaultKey) {
+            setError('Vault key not available. Please log in again.');
+            setLoading(false);
+            return;
+        }
+
+        try {
+            setLoading(true);
+            const {data} = await apiRequest<VaultRecord[]>('/api/vault/records/', {
+              method: 'GET',
+              requiresAuth: true
+            });
+            
+            // Decrypt sensitive fields
+            const decryptedRecords = await Promise.all(
+                data.map(async (record) => ({
+                    ...record,
+                    password: await decryptVaultEntry(vaultKey, record.password),
+                    notes: record.notes ? await decryptVaultEntry(vaultKey, record.notes) : '',
+                }))
+            );
+            
+            setRecords(decryptedRecords);
+          } catch (err) {
+            setError(getErrorMessage(err));
+            console.error('Error fetching records:', err);
+          } finally {
+            setLoading(false);
+          }
+    }, [vaultKey]);
+
+    // Mutations without loading spinner
+    const performMutation = async function<T>(
+        apiCall: Promise<T>
+    ): Promise<boolean> {
+        try {
+            setError(null);
+            setFieldErrors({});
+            await apiCall;
+            await fetchRecords(); // Re-fetch after any mutation
+            return true;
+        } catch (err) {
+            const fieldErrs = extractFieldErrors(err);
+            if (Object.keys(fieldErrs).length > 0) {
+                setFieldErrors(fieldErrs);
+                setError('Please fix the validation errors below.');
+            } else {
+                setError(getErrorMessage(err));
+            }
+            console.error('Error:', err);
+            return false;
+        }
+    };
+
+    useEffect(() => {
+        fetchRecords();
+      }, [fetchRecords]);
+
+    const onAddRecord = () => {
+        setEditingRecord(null);
+        }
+    
+    const onEditRecord = (record: VaultRecord) => {
+        setEditingRecord(record);
+    }
+
+    const onSelectRecord = (record: VaultRecord) => {
+        setSelectedRecord(record);
+    }
+
+    const onCancel = () => {
+        setEditingRecord(undefined);
+    }
+
+    const onCloseDetails = () => {
+        setSelectedRecord(null);
+    }
+
+    const onDeleteRecord = async (record: VaultRecord) => {
+        const success = await performMutation(
+        apiRequest(`/api/vault/records/${record.id}/`, {
+            method: 'DELETE',
+            requiresAuth: true
+        }));
+        if (success) {
+            setSelectedRecord(null);
+        }
+    }
+
+    const handleRecordSubmit = async (record: VaultRecord) => {
+        if (!vaultKey) {
+            setError('Vault key not available. Cannot save record.');
+            return;
+        }
+
+        // Encrypt sensitive fields before sending
+        const encryptedRecord = {
+            ...record,
+            password: await encryptVaultEntry(vaultKey, record.password),
+            notes: record.notes ? await encryptVaultEntry(vaultKey, record.notes) : '',
+        };
+
+        const success = await performMutation(
+            apiRequest(
+                editingRecord ? `/api/vault/records/${editingRecord.id}/` : '/api/vault/records/',
+                {
+                    method: editingRecord ? 'PUT' : 'POST',
+                    body: encryptedRecord,
+                    requiresAuth: true
+                }
+            ));
+        if (success) {
+            setEditingRecord(undefined);
+        }
+    }
+    
+    
+    return (
+        <div className={styles.vaultContainer}>
+            <div className={styles.vaultContent}>
+                <h1>Vault</h1>
+
+                {loading && (
+                    <Spacer paddingY="xl">
+                        <LoadingSpinner size="large" text="Loading your vault..." />
+                    </Spacer>
+                )}
+
+                {error && <p style={{ color: 'var(--color-error)' }}>Error: {error}</p>}
+
+                {!loading && !error && (
+                <div className={styles.vaultLayout}>
+                    <div className={styles.leftColumn}>
+                        <VaultList 
+                            records={records} 
+                            onAddRecord={onAddRecord} 
+                            onEditRecord={onEditRecord} 
+                            onSelectRecord={onSelectRecord}
+                        />
+                    </div>
+                    <div className={styles.rightColumn}>
+
+                        {editingRecord !== undefined && (
+                            <RecordForm 
+                                record={editingRecord} 
+                                onSubmit={handleRecordSubmit} 
+                                onCancel={onCancel} 
+                            />
+                        )}
+                        
+                        {selectedRecord && editingRecord === undefined && (
+                            <RecordDetails 
+                                record={selectedRecord} 
+                                onClose={onCloseDetails}
+                                onDelete={onDeleteRecord}
+                            />
+                        )}
+                    </div>
+                </div>
+            )}
+            </div>
+        </div>
+    )
+}
+```
+
+```typescriptreact
+/*
+This creates the Vault page using React.
+
+Note:
+To start the Vite dev server, run: 'npm run dev' in the frontend/web directory.
+
+GenAI Citation for April:
+Portions of this code was generated/refactored with the help of Cursor with the Claude-4.5-sonnet model
+The conversation in the file below documents the GenAI Interaction that led to my code.
+../GenAI_transcripts/2025_11_14_Cursor_generate_dummy_data_for_Vault.md
+../GenAI_transcripts/2025_11_14_Cursor_style_Vault_components.md
+*/
+
+import { useState, useEffect, useCallback } from 'react';
+import type { VaultRecord as VaultRecord } from '../types/VaultRecord';
+import styles from './Vault.module.css';
+import { VaultList } from '../components/VaultList';
+import { RecordForm } from '../components/RecordForm';
+import { RecordDetails } from '../components/RecordDetails';
+import { LoadingSpinner } from '../components/LoadingSpinner';
+import { Spacer } from '../components/Spacer';
+import { apiRequest } from '../utils/http/apiRequest';
+import { useVaultKey } from '../contexts/useVaultKey';
+import { encryptVaultEntry } from '../utils/crypto/encryptVaultEntry';
+import { decryptVaultEntry } from '../utils/crypto/decryptVaultEntry';
+
+
+export const VaultPage = () => {
+    const [records, setRecords] = useState<VaultRecord[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+
+    const [editingRecord, setEditingRecord] = useState<VaultRecord | null | undefined>(undefined);
+    const [selectedRecord, setSelectedRecord] = useState<VaultRecord | null >(null);
+    
+    const { vaultKey } = useVaultKey();
+
+    const getErrorMessage = (err: unknown): string => {
+        if (err instanceof Error) return err.message;
+        if (typeof err === 'object' && err !== null && 'message' in err) {
+          return String(err.message);
+        }
+        return 'An error occurred';
+      };
+
+    const extractFieldErrors = (err: unknown): Record<string, string[]> => {
+        if (typeof err === 'object' && err !== null && 'data' in err) {
+            const data = (err as { data: unknown }).data;
+            if (typeof data === 'object' && data !== null) {
+                // Filter out non-field error properties
+                const fieldErrors: Record<string, string[]> = {};
+                for (const [key, value] of Object.entries(data)) {
+                    if (Array.isArray(value)) {
+                        fieldErrors[key] = value;
+                    }
+                }
+                return fieldErrors;
+            }
+        }
+        return {};
+    };
+
+    const fetchRecords = useCallback(async () => {
+        if (!vaultKey) {
+            setError('Vault key not available. Please log in again.');
+            setLoading(false);
+            return;
+        }
+
+        try {
+            setLoading(true);
+            const {data} = await apiRequest<VaultRecord[]>('/api/vault/records/', {
+              method: 'GET',
+              requiresAuth: true
+            });
+            
+            // Decrypt sensitive fields
+            const decryptedRecords = await Promise.all(
+                data.map(async (record) => ({
+                    ...record,
+                    password: await decryptVaultEntry(vaultKey, record.password),
+                    notes: record.notes ? await decryptVaultEntry(vaultKey, record.notes) : '',
+                }))
+            );
+            
+            setRecords(decryptedRecords);
+          } catch (err) {
+            setError(getErrorMessage(err));
+            console.error('Error fetching records:', err);
+          } finally {
+            setLoading(false);
+          }
+    }, [vaultKey]);
+
+    // Mutations without loading spinner
+    const performMutation = async function<T>(
+        apiCall: Promise<T>
+    ): Promise<boolean> {
+        try {
+            setError(null);
+            setFieldErrors({});
+            await apiCall;
+            await fetchRecords(); // Re-fetch after any mutation
+            return true;
+        } catch (err) {
+            const fieldErrs = extractFieldErrors(err);
+            if (Object.keys(fieldErrs).length > 0) {
+                setFieldErrors(fieldErrs);
+                setError('Please fix the validation errors below.');
+            } else {
+                setError(getErrorMessage(err));
+            }
+            console.error('Error:', err);
+            return false;
+        }
+    };
+
+    useEffect(() => {
+        fetchRecords();
+      }, [fetchRecords]);
+
+    const onAddRecord = () => {
+        setEditingRecord(null);
+        }
+    
+    const onEditRecord = (record: VaultRecord) => {
+        setEditingRecord(record);
+    }
+
+    const onSelectRecord = (record: VaultRecord) => {
+        setSelectedRecord(record);
+    }
+
+    const onCancel = () => {
+        setEditingRecord(undefined);
+        setFieldErrors({});
+        setError(null);
+    }
+
+    const onCloseDetails = () => {
+        setSelectedRecord(null);
+    }
+
+    const onDeleteRecord = async (record: VaultRecord) => {
+        const success = await performMutation(
+        apiRequest(`/api/vault/records/${record.id}/`, {
+            method: 'DELETE',
+            requiresAuth: true
+        }));
+        if (success) {
+            setSelectedRecord(null);
+        }
+    }
+
+    const handleRecordSubmit = async (record: VaultRecord) => {
+        if (!vaultKey) {
+            setError('Vault key not available. Cannot save record.');
+            return;
+        }
+
+        // Encrypt sensitive fields before sending
+        const encryptedRecord = {
+            ...record,
+            password: await encryptVaultEntry(vaultKey, record.password),
+            notes: record.notes ? await encryptVaultEntry(vaultKey, record.notes) : '',
+        };
+
+        const success = await performMutation(
+            apiRequest(
+                editingRecord ? `/api/vault/records/${editingRecord.id}/` : '/api/vault/records/',
+                {
+                    method: editingRecord ? 'PUT' : 'POST',
+                    body: encryptedRecord,
+                    requiresAuth: true
+                }
+            ));
+        if (success) {
+            setEditingRecord(undefined);
+        }
+    }
+    
+    
+    return (
+        <div className={styles.vaultContainer}>
+            <div className={styles.vaultContent}>
+                <h1>Vault</h1>
+
+                {loading && (
+                    <Spacer paddingY="xl">
+                        <LoadingSpinner size="large" text="Loading your vault..." />
+                    </Spacer>
+                )}
+
+                {error && <p style={{ color: 'var(--color-error)' }}>Error: {error}</p>}
+
+                {!loading && !error && (
+                <div className={styles.vaultLayout}>
+                    <div className={styles.leftColumn}>
+                        <VaultList 
+                            records={records} 
+                            onAddRecord={onAddRecord} 
+                            onEditRecord={onEditRecord} 
+                            onSelectRecord={onSelectRecord}
+                        />
+                    </div>
+                    <div className={styles.rightColumn}>
+
+                        {editingRecord !== undefined && (
+                            <RecordForm 
+                                record={editingRecord} 
+                                onSubmit={handleRecordSubmit} 
+                                onCancel={onCancel} 
+                            />
+                        )}
+                        
+                        {selectedRecord && editingRecord === undefined && (
+                            <RecordDetails 
+                                record={selectedRecord} 
+                                onClose={onCloseDetails}
+                                onDelete={onDeleteRecord}
+                            />
+                        )}
+                    </div>
+                </div>
+            )}
+            </div>
+        </div>
+    )
+}
+```
+
+```typescriptreact
+/*
+This creates the Vault page using React.
+
+Note:
+To start the Vite dev server, run: 'npm run dev' in the frontend/web directory.
+
+GenAI Citation for April:
+Portions of this code was generated/refactored with the help of Cursor with the Claude-4.5-sonnet model
+The conversation in the file below documents the GenAI Interaction that led to my code.
+../GenAI_transcripts/2025_11_14_Cursor_generate_dummy_data_for_Vault.md
+../GenAI_transcripts/2025_11_14_Cursor_style_Vault_components.md
+*/
+
+import { useState, useEffect, useCallback } from 'react';
+import type { VaultRecord as VaultRecord } from '../types/VaultRecord';
+import styles from './Vault.module.css';
+import { VaultList } from '../components/VaultList';
+import { RecordForm } from '../components/RecordForm';
+import { RecordDetails } from '../components/RecordDetails';
+import { LoadingSpinner } from '../components/LoadingSpinner';
+import { Spacer } from '../components/Spacer';
+import { apiRequest } from '../utils/http/apiRequest';
+import { useVaultKey } from '../contexts/useVaultKey';
+import { encryptVaultEntry } from '../utils/crypto/encryptVaultEntry';
+import { decryptVaultEntry } from '../utils/crypto/decryptVaultEntry';
+
+
+export const VaultPage = () => {
+    const [records, setRecords] = useState<VaultRecord[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+
+    const [editingRecord, setEditingRecord] = useState<VaultRecord | null | undefined>(undefined);
+    const [selectedRecord, setSelectedRecord] = useState<VaultRecord | null >(null);
+    
+    const { vaultKey } = useVaultKey();
+
+    const getErrorMessage = (err: unknown): string => {
+        if (err instanceof Error) return err.message;
+        if (typeof err === 'object' && err !== null && 'message' in err) {
+          return String(err.message);
+        }
+        return 'An error occurred';
+      };
+
+    const extractFieldErrors = (err: unknown): Record<string, string[]> => {
+        if (typeof err === 'object' && err !== null && 'data' in err) {
+            const data = (err as { data: unknown }).data;
+            if (typeof data === 'object' && data !== null) {
+                // Filter out non-field error properties
+                const fieldErrors: Record<string, string[]> = {};
+                for (const [key, value] of Object.entries(data)) {
+                    if (Array.isArray(value)) {
+                        fieldErrors[key] = value;
+                    }
+                }
+                return fieldErrors;
+            }
+        }
+        return {};
+    };
+
+    const fetchRecords = useCallback(async () => {
+        if (!vaultKey) {
+            setError('Vault key not available. Please log in again.');
+            setLoading(false);
+            return;
+        }
+
+        try {
+            setLoading(true);
+            const {data} = await apiRequest<VaultRecord[]>('/api/vault/records/', {
+              method: 'GET',
+              requiresAuth: true
+            });
+            
+            // Decrypt sensitive fields
+            const decryptedRecords = await Promise.all(
+                data.map(async (record) => ({
+                    ...record,
+                    password: await decryptVaultEntry(vaultKey, record.password),
+                    notes: record.notes ? await decryptVaultEntry(vaultKey, record.notes) : '',
+                }))
+            );
+            
+            setRecords(decryptedRecords);
+          } catch (err) {
+            setError(getErrorMessage(err));
+            console.error('Error fetching records:', err);
+          } finally {
+            setLoading(false);
+          }
+    }, [vaultKey]);
+
+    // Mutations without loading spinner
+    const performMutation = async function<T>(
+        apiCall: Promise<T>
+    ): Promise<boolean> {
+        try {
+            setError(null);
+            setFieldErrors({});
+            await apiCall;
+            await fetchRecords(); // Re-fetch after any mutation
+            return true;
+        } catch (err) {
+            const fieldErrs = extractFieldErrors(err);
+            if (Object.keys(fieldErrs).length > 0) {
+                setFieldErrors(fieldErrs);
+                setError('Please fix the validation errors below.');
+            } else {
+                setError(getErrorMessage(err));
+            }
+            console.error('Error:', err);
+            return false;
+        }
+    };
+
+    useEffect(() => {
+        fetchRecords();
+      }, [fetchRecords]);
+
+    const onAddRecord = () => {
+        setEditingRecord(null);
+        setFieldErrors({});
+        setError(null);
+        }
+    
+    const onEditRecord = (record: VaultRecord) => {
+        setEditingRecord(record);
+    }
+
+    const onSelectRecord = (record: VaultRecord) => {
+        setSelectedRecord(record);
+    }
+
+    const onCancel = () => {
+        setEditingRecord(undefined);
+        setFieldErrors({});
+        setError(null);
+    }
+
+    const onCloseDetails = () => {
+        setSelectedRecord(null);
+    }
+
+    const onDeleteRecord = async (record: VaultRecord) => {
+        const success = await performMutation(
+        apiRequest(`/api/vault/records/${record.id}/`, {
+            method: 'DELETE',
+            requiresAuth: true
+        }));
+        if (success) {
+            setSelectedRecord(null);
+        }
+    }
+
+    const handleRecordSubmit = async (record: VaultRecord) => {
+        if (!vaultKey) {
+            setError('Vault key not available. Cannot save record.');
+            return;
+        }
+
+        // Encrypt sensitive fields before sending
+        const encryptedRecord = {
+            ...record,
+            password: await encryptVaultEntry(vaultKey, record.password),
+            notes: record.notes ? await encryptVaultEntry(vaultKey, record.notes) : '',
+        };
+
+        const success = await performMutation(
+            apiRequest(
+                editingRecord ? `/api/vault/records/${editingRecord.id}/` : '/api/vault/records/',
+                {
+                    method: editingRecord ? 'PUT' : 'POST',
+                    body: encryptedRecord,
+                    requiresAuth: true
+                }
+            ));
+        if (success) {
+            setEditingRecord(undefined);
+        }
+    }
+    
+    
+    return (
+        <div className={styles.vaultContainer}>
+            <div className={styles.vaultContent}>
+                <h1>Vault</h1>
+
+                {loading && (
+                    <Spacer paddingY="xl">
+                        <LoadingSpinner size="large" text="Loading your vault..." />
+                    </Spacer>
+                )}
+
+                {error && <p style={{ color: 'var(--color-error)' }}>Error: {error}</p>}
+
+                {!loading && !error && (
+                <div className={styles.vaultLayout}>
+                    <div className={styles.leftColumn}>
+                        <VaultList 
+                            records={records} 
+                            onAddRecord={onAddRecord} 
+                            onEditRecord={onEditRecord} 
+                            onSelectRecord={onSelectRecord}
+                        />
+                    </div>
+                    <div className={styles.rightColumn}>
+
+                        {editingRecord !== undefined && (
+                            <RecordForm 
+                                record={editingRecord} 
+                                onSubmit={handleRecordSubmit} 
+                                onCancel={onCancel} 
+                            />
+                        )}
+                        
+                        {selectedRecord && editingRecord === undefined && (
+                            <RecordDetails 
+                                record={selectedRecord} 
+                                onClose={onCloseDetails}
+                                onDelete={onDeleteRecord}
+                            />
+                        )}
+                    </div>
+                </div>
+            )}
+            </div>
+        </div>
+    )
+}
+```
+
+```typescriptreact
+/*
+This creates the Vault page using React.
+
+Note:
+To start the Vite dev server, run: 'npm run dev' in the frontend/web directory.
+
+GenAI Citation for April:
+Portions of this code was generated/refactored with the help of Cursor with the Claude-4.5-sonnet model
+The conversation in the file below documents the GenAI Interaction that led to my code.
+../GenAI_transcripts/2025_11_14_Cursor_generate_dummy_data_for_Vault.md
+../GenAI_transcripts/2025_11_14_Cursor_style_Vault_components.md
+*/
+
+import { useState, useEffect, useCallback } from 'react';
+import type { VaultRecord as VaultRecord } from '../types/VaultRecord';
+import styles from './Vault.module.css';
+import { VaultList } from '../components/VaultList';
+import { RecordForm } from '../components/RecordForm';
+import { RecordDetails } from '../components/RecordDetails';
+import { LoadingSpinner } from '../components/LoadingSpinner';
+import { Spacer } from '../components/Spacer';
+import { apiRequest } from '../utils/http/apiRequest';
+import { useVaultKey } from '../contexts/useVaultKey';
+import { encryptVaultEntry } from '../utils/crypto/encryptVaultEntry';
+import { decryptVaultEntry } from '../utils/crypto/decryptVaultEntry';
+
+
+export const VaultPage = () => {
+    const [records, setRecords] = useState<VaultRecord[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+
+    const [editingRecord, setEditingRecord] = useState<VaultRecord | null | undefined>(undefined);
+    const [selectedRecord, setSelectedRecord] = useState<VaultRecord | null >(null);
+    
+    const { vaultKey } = useVaultKey();
+
+    const getErrorMessage = (err: unknown): string => {
+        if (err instanceof Error) return err.message;
+        if (typeof err === 'object' && err !== null && 'message' in err) {
+          return String(err.message);
+        }
+        return 'An error occurred';
+      };
+
+    const extractFieldErrors = (err: unknown): Record<string, string[]> => {
+        if (typeof err === 'object' && err !== null && 'data' in err) {
+            const data = (err as { data: unknown }).data;
+            if (typeof data === 'object' && data !== null) {
+                // Filter out non-field error properties
+                const fieldErrors: Record<string, string[]> = {};
+                for (const [key, value] of Object.entries(data)) {
+                    if (Array.isArray(value)) {
+                        fieldErrors[key] = value;
+                    }
+                }
+                return fieldErrors;
+            }
+        }
+        return {};
+    };
+
+    const fetchRecords = useCallback(async () => {
+        if (!vaultKey) {
+            setError('Vault key not available. Please log in again.');
+            setLoading(false);
+            return;
+        }
+
+        try {
+            setLoading(true);
+            const {data} = await apiRequest<VaultRecord[]>('/api/vault/records/', {
+              method: 'GET',
+              requiresAuth: true
+            });
+            
+            // Decrypt sensitive fields
+            const decryptedRecords = await Promise.all(
+                data.map(async (record) => ({
+                    ...record,
+                    password: await decryptVaultEntry(vaultKey, record.password),
+                    notes: record.notes ? await decryptVaultEntry(vaultKey, record.notes) : '',
+                }))
+            );
+            
+            setRecords(decryptedRecords);
+          } catch (err) {
+            setError(getErrorMessage(err));
+            console.error('Error fetching records:', err);
+          } finally {
+            setLoading(false);
+          }
+    }, [vaultKey]);
+
+    // Mutations without loading spinner
+    const performMutation = async function<T>(
+        apiCall: Promise<T>
+    ): Promise<boolean> {
+        try {
+            setError(null);
+            setFieldErrors({});
+            await apiCall;
+            await fetchRecords(); // Re-fetch after any mutation
+            return true;
+        } catch (err) {
+            const fieldErrs = extractFieldErrors(err);
+            if (Object.keys(fieldErrs).length > 0) {
+                setFieldErrors(fieldErrs);
+                setError('Please fix the validation errors below.');
+            } else {
+                setError(getErrorMessage(err));
+            }
+            console.error('Error:', err);
+            return false;
+        }
+    };
+
+    useEffect(() => {
+        fetchRecords();
+      }, [fetchRecords]);
+
+    const onAddRecord = () => {
+        setEditingRecord(null);
+        setFieldErrors({});
+        setError(null);
+        }
+    
+    const onEditRecord = (record: VaultRecord) => {
+        setEditingRecord(record);
+    }
+
+    const onSelectRecord = (record: VaultRecord) => {
+        setSelectedRecord(record);
+    }
+
+    const onCancel = () => {
+        setEditingRecord(undefined);
+        setFieldErrors({});
+        setError(null);
+    }
+
+    const onCloseDetails = () => {
+        setSelectedRecord(null);
+    }
+
+    const onDeleteRecord = async (record: VaultRecord) => {
+        const success = await performMutation(
+        apiRequest(`/api/vault/records/${record.id}/`, {
+            method: 'DELETE',
+            requiresAuth: true
+        }));
+        if (success) {
+            setSelectedRecord(null);
+        }
+    }
+
+    const handleRecordSubmit = async (record: VaultRecord) => {
+        if (!vaultKey) {
+            setError('Vault key not available. Cannot save record.');
+            return;
+        }
+
+        // Encrypt sensitive fields before sending
+        const encryptedRecord = {
+            ...record,
+            password: await encryptVaultEntry(vaultKey, record.password),
+            notes: record.notes ? await encryptVaultEntry(vaultKey, record.notes) : '',
+        };
+
+        const success = await performMutation(
+            apiRequest(
+                editingRecord ? `/api/vault/records/${editingRecord.id}/` : '/api/vault/records/',
+                {
+                    method: editingRecord ? 'PUT' : 'POST',
+                    body: encryptedRecord,
+                    requiresAuth: true
+                }
+            ));
+        if (success) {
+            setEditingRecord(undefined);
+        }
+    }
+    
+    
+    return (
+        <div className={styles.vaultContainer}>
+            <div className={styles.vaultContent}>
+                <h1>Vault</h1>
+
+                {loading && (
+                    <Spacer paddingY="xl">
+                        <LoadingSpinner size="large" text="Loading your vault..." />
+                    </Spacer>
+                )}
+
+                {error && <p style={{ color: 'var(--color-error)' }}>Error: {error}</p>}
+
+                {!loading && !error && (
+                <div className={styles.vaultLayout}>
+                    <div className={styles.leftColumn}>
+                        <VaultList 
+                            records={records} 
+                            onAddRecord={onAddRecord} 
+                            onEditRecord={onEditRecord} 
+                            onSelectRecord={onSelectRecord}
+                        />
+                    </div>
+                    <div className={styles.rightColumn}>
+
+                        {editingRecord !== undefined && (
+                            <RecordForm 
+                                record={editingRecord} 
+                                onSubmit={handleRecordSubmit} 
+                                onCancel={onCancel} 
+                                fieldErrors={fieldErrors}
+                            />
+                        )}
+                        
+                        {selectedRecord && editingRecord === undefined && (
+                            <RecordDetails 
+                                record={selectedRecord} 
+                                onClose={onCloseDetails}
+                                onDelete={onDeleteRecord}
+                            />
+                        )}
+                    </div>
+                </div>
+            )}
+            </div>
+        </div>
+    )
+}
+```
+
+Let me verify the changes look correct:
+
+Perfect! The validation error wasn't displaying on screen because:
+
+## The Problem
+
+1. **API returns field-specific errors**: When validation fails, the API returns a 400 response with errors like `{email: ["Enter a valid email address."]}`
+
+2. **Error handling only extracted generic messages**: The `performMutation` function in `Vault.tsx` caught errors but only extracted a generic error message, ignoring the field-specific validation errors in the response
+
+3. **Form didn't accept field errors**: The `RecordForm` component had no way to receive or display field-specific validation errors
+
+4. **Input components were ready but unused**: The `Input` and `Textarea` components already supported an `error` prop, but it was never being used
+
+## The Fix
+
+I've updated the code to properly display validation errors:
+
+1. **Added `fieldErrors` state** to `Vault.tsx` to track field-specific validation errors
+
+2. **Created `extractFieldErrors` helper** that extracts field-specific validation errors from API error responses
+
+3. **Updated `performMutation`** to extract and set field errors when they exist
+
+4. **Updated `RecordForm`** to accept a `fieldErrors` prop and pass errors to each Input/Textarea component
+
+5. **Clear errors properly** when opening/closing forms
+
+Now when you submit invalid data (like "foo@bar" for email), the validation error will appear directly below the email input field in red text, just like the helper text does for valid fields.
+
+---
+
+**User**
+
+When I submit an invalid new record request, it shows this instead of an error message directly below the @RecordForm.tsx  input field.
+
+This is likely due to this line @Vault.tsx (197) and the usage of setError here @Vault.tsx (110). SetError should only be used for messages in the /vault page that will cause the vault records to not show. 
+
+---
+
+**Cursor**
+
+You're right. The `setError` is for page-level errors that prevent the vault from loading, not for field validation errors. The field errors should only display inline in the form.
+
+```typescriptreact
+/*
+This creates the Vault page using React.
+
+Note:
+To start the Vite dev server, run: 'npm run dev' in the frontend/web directory.
+
+GenAI Citation for April:
+Portions of this code was generated/refactored with the help of Cursor with the Claude-4.5-sonnet model
+The conversation in the file below documents the GenAI Interaction that led to my code.
+../GenAI_transcripts/2025_11_14_Cursor_generate_dummy_data_for_Vault.md
+../GenAI_transcripts/2025_11_14_Cursor_style_Vault_components.md
+*/
+
+import { useState, useEffect, useCallback } from 'react';
+import type { VaultRecord as VaultRecord } from '../types/VaultRecord';
+import styles from './Vault.module.css';
+import { VaultList } from '../components/VaultList';
+import { RecordForm } from '../components/RecordForm';
+import { RecordDetails } from '../components/RecordDetails';
+import { LoadingSpinner } from '../components/LoadingSpinner';
+import { Spacer } from '../components/Spacer';
+import { apiRequest } from '../utils/http/apiRequest';
+import { useVaultKey } from '../contexts/useVaultKey';
+import { encryptVaultEntry } from '../utils/crypto/encryptVaultEntry';
+import { decryptVaultEntry } from '../utils/crypto/decryptVaultEntry';
+
+
+export const VaultPage = () => {
+    const [records, setRecords] = useState<VaultRecord[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+
+    const [editingRecord, setEditingRecord] = useState<VaultRecord | null | undefined>(undefined);
+    const [selectedRecord, setSelectedRecord] = useState<VaultRecord | null >(null);
+    
+    const { vaultKey } = useVaultKey();
+
+    const getErrorMessage = (err: unknown): string => {
+        if (err instanceof Error) return err.message;
+        if (typeof err === 'object' && err !== null && 'message' in err) {
+          return String(err.message);
+        }
+        return 'An error occurred';
+      };
+
+    const extractFieldErrors = (err: unknown): Record<string, string[]> => {
+        if (typeof err === 'object' && err !== null && 'data' in err) {
+            const data = (err as { data: unknown }).data;
+            if (typeof data === 'object' && data !== null) {
+                // Filter out non-field error properties
+                const fieldErrors: Record<string, string[]> = {};
+                for (const [key, value] of Object.entries(data)) {
+                    if (Array.isArray(value)) {
+                        fieldErrors[key] = value;
+                    }
+                }
+                return fieldErrors;
+            }
+        }
+        return {};
+    };
+
+    const fetchRecords = useCallback(async () => {
+        if (!vaultKey) {
+            setError('Vault key not available. Please log in again.');
+            setLoading(false);
+            return;
+        }
+
+        try {
+            setLoading(true);
+            const {data} = await apiRequest<VaultRecord[]>('/api/vault/records/', {
+              method: 'GET',
+              requiresAuth: true
+            });
+            
+            // Decrypt sensitive fields
+            const decryptedRecords = await Promise.all(
+                data.map(async (record) => ({
+                    ...record,
+                    password: await decryptVaultEntry(vaultKey, record.password),
+                    notes: record.notes ? await decryptVaultEntry(vaultKey, record.notes) : '',
+                }))
+            );
+            
+            setRecords(decryptedRecords);
+          } catch (err) {
+            setError(getErrorMessage(err));
+            console.error('Error fetching records:', err);
+          } finally {
+            setLoading(false);
+          }
+    }, [vaultKey]);
+
+    // Mutations without loading spinner
+    const performMutation = async function<T>(
+        apiCall: Promise<T>
+    ): Promise<boolean> {
+        try {
+            setError(null);
+            setFieldErrors({});
+            await apiCall;
+            await fetchRecords(); // Re-fetch after any mutation
+            return true;
+        } catch (err) {
+            const fieldErrs = extractFieldErrors(err);
+            if (Object.keys(fieldErrs).length > 0) {
+                setFieldErrors(fieldErrs);
+            } else {
+                setError(getErrorMessage(err));
+            }
+            console.error('Error:', err);
+            return false;
+        }
+    };
+
+    useEffect(() => {
+        fetchRecords();
+      }, [fetchRecords]);
+
+    const onAddRecord = () => {
+        setEditingRecord(null);
+        setFieldErrors({});
+        setError(null);
+        }
+    
+    const onEditRecord = (record: VaultRecord) => {
+        setEditingRecord(record);
+    }
+
+    const onSelectRecord = (record: VaultRecord) => {
+        setSelectedRecord(record);
+    }
+
+    const onCancel = () => {
+        setEditingRecord(undefined);
+        setFieldErrors({});
+        setError(null);
+    }
+
+    const onCloseDetails = () => {
+        setSelectedRecord(null);
+    }
+
+    const onDeleteRecord = async (record: VaultRecord) => {
+        const success = await performMutation(
+        apiRequest(`/api/vault/records/${record.id}/`, {
+            method: 'DELETE',
+            requiresAuth: true
+        }));
+        if (success) {
+            setSelectedRecord(null);
+        }
+    }
+
+    const handleRecordSubmit = async (record: VaultRecord) => {
+        if (!vaultKey) {
+            setError('Vault key not available. Cannot save record.');
+            return;
+        }
+
+        // Encrypt sensitive fields before sending
+        const encryptedRecord = {
+            ...record,
+            password: await encryptVaultEntry(vaultKey, record.password),
+            notes: record.notes ? await encryptVaultEntry(vaultKey, record.notes) : '',
+        };
+
+        const success = await performMutation(
+            apiRequest(
+                editingRecord ? `/api/vault/records/${editingRecord.id}/` : '/api/vault/records/',
+                {
+                    method: editingRecord ? 'PUT' : 'POST',
+                    body: encryptedRecord,
+                    requiresAuth: true
+                }
+            ));
+        if (success) {
+            setEditingRecord(undefined);
+        }
+    }
+    
+    
+    return (
+        <div className={styles.vaultContainer}>
+            <div className={styles.vaultContent}>
+                <h1>Vault</h1>
+
+                {loading && (
+                    <Spacer paddingY="xl">
+                        <LoadingSpinner size="large" text="Loading your vault..." />
+                    </Spacer>
+                )}
+
+                {error && <p style={{ color: 'var(--color-error)' }}>Error: {error}</p>}
+
+                {!loading && !error && (
+                <div className={styles.vaultLayout}>
+                    <div className={styles.leftColumn}>
+                        <VaultList 
+                            records={records} 
+                            onAddRecord={onAddRecord} 
+                            onEditRecord={onEditRecord} 
+                            onSelectRecord={onSelectRecord}
+                        />
+                    </div>
+                    <div className={styles.rightColumn}>
+
+                        {editingRecord !== undefined && (
+                            <RecordForm 
+                                record={editingRecord} 
+                                onSubmit={handleRecordSubmit} 
+                                onCancel={onCancel} 
+                                fieldErrors={fieldErrors}
+                            />
+                        )}
+                        
+                        {selectedRecord && editingRecord === undefined && (
+                            <RecordDetails 
+                                record={selectedRecord} 
+                                onClose={onCloseDetails}
+                                onDelete={onDeleteRecord}
+                            />
+                        )}
+                    </div>
+                </div>
+            )}
+            </div>
+        </div>
+    )
+}
+```
+
+Done. Now validation errors will only appear inline below the specific input fields, not as a page-level error message.
+

--- a/frontend/web/src/components/RecordForm.tsx
+++ b/frontend/web/src/components/RecordForm.tsx
@@ -4,6 +4,7 @@
 // ../GenAI_transcripts/2025_11_15_Cursor_refactor_UI.md
 // ../GenAI_transcripts/2025_11_14_Cursor_style_Vault_components.md
 // ../GenAI_transcripts/2025_11_18_Cursor_RecordForm_UI_refactor.md
+// ../GenAI_transcripts/2025_11_24_Cursor_Error_Message_Display.md
 
 import { useState, type FC, type FormEvent } from "react";
 import type { VaultRecord } from "../types/VaultRecord";
@@ -13,7 +14,14 @@ import {Button} from "./Button";
 import {Input, Textarea} from "./Input";
 import styles from "./RecordForm.module.css";
 
-export const RecordForm:FC<{record: VaultRecord | null, onSubmit: (record: VaultRecord) => Promise<void>, onCancel: () => void}> = ({record, onSubmit, onCancel}) => {
+interface RecordFormProps {
+    record: VaultRecord | null;
+    onSubmit: (record: VaultRecord) => Promise<void>;
+    onCancel: () => void;
+    fieldErrors?: Record<string, string[]>;
+}
+
+export const RecordForm:FC<RecordFormProps> = ({record, onSubmit, onCancel, fieldErrors = {}}) => {
 
     const [formState, setFormState] = useState<Pick<VaultRecord, 'title' | 'username' | 'password' | 'email' | 'url' | 'notes'>>({
         title: record?.title ?? '',
@@ -64,6 +72,7 @@ export const RecordForm:FC<{record: VaultRecord | null, onSubmit: (record: Vault
                 value={formState.title}
                 required
                 onChange={(e) => setFormState({...formState, title: e.target.value})}
+                error={fieldErrors.title?.[0]}
             />
             <Input
                 label="Username:"
@@ -71,6 +80,7 @@ export const RecordForm:FC<{record: VaultRecord | null, onSubmit: (record: Vault
                 value={formState.username}
                 required
                 onChange={(e) => setFormState({...formState, username: e.target.value})}
+                error={fieldErrors.username?.[0]}
             />
             <Input
                 label="Password:"
@@ -79,12 +89,14 @@ export const RecordForm:FC<{record: VaultRecord | null, onSubmit: (record: Vault
                 required
                 onChange={(e) => setFormState({...formState, password: e.target.value})}
                 secondaryRightAdornment={<PasswordToggleButton />}
+                error={fieldErrors.password?.[0]}
             />
             <Input
                 label="Email:"
                 type="email"
                 value={formState.email}
                 onChange={(e) => setFormState({...formState, email: e.target.value})}
+                error={fieldErrors.email?.[0]}
                 helperText="Optional - Associated email address"
             />
             <Input
@@ -92,12 +104,14 @@ export const RecordForm:FC<{record: VaultRecord | null, onSubmit: (record: Vault
                 type="url"
                 value={formState.url}
                 onChange={(e) => setFormState({...formState, url: e.target.value})}
+                error={fieldErrors.url?.[0]}
                 helperText="Optional - Website URL"
             />
             <Textarea
                 label="Notes:"
                 value={formState.notes}
                 onChange={(e) => setFormState({...formState, notes: e.target.value})}
+                error={fieldErrors.notes?.[0]}
                 helperText="Optional - Additional information"
             />
             <div className={styles.buttonGroup}>

--- a/frontend/web/src/utils/typeguards/isObjectLike.ts
+++ b/frontend/web/src/utils/typeguards/isObjectLike.ts
@@ -1,0 +1,6 @@
+
+
+
+export const isObjectLike = (value: unknown): value is Record<string, unknown> => {
+    return typeof value === 'object' && value !== null;
+};


### PR DESCRIPTION
GenAI Citation:
Portions of this code was generated/refactored with the help of Cursor with the Claude-4.5-sonnet model
[The conversations in the file linked documents the GenAI Interaction that led to my code.](https://github.com/beckywong37/secure-password-manager/compare/fix/display-input-errors?expand=1#diff-846799d7f818715fb41f4f0ab67f764a22e092f110b09bfff5d3fe8eade265fb)

Last PR broke error messages for bad requests on RecordForm (aka when user input an invalid email)

Example of fixed behavior:
<img width="352" height="787" alt="image" src="https://github.com/user-attachments/assets/aa6de227-2074-4880-9000-a73f978496f1" />
